### PR TITLE
Fixup index output location

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,5 +21,6 @@
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true
   },
+  "include": ["src/**/*.ts"],
   "exclude": ["node_modules", "dist", "src/**/*.test.ts"]
 }


### PR DESCRIPTION
## Changes

By default TS was including jest config in build output, and was mispositioning where the index.js file gets put (`dist/src/index`).

This change fixes index to be at `dist/index`.

## Checklist

- [x] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`

⚠️ No JIRA ticket for this task ⚠️
