### PR TITLE
Adjusted import type from `module` to `commonjs`

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   ],
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "type": "module",
+  "type": "commonjs",
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
Applied `minor` label, as this is not exactly a patch change, but definitely also not major.
No Jira ticket for this task.