### PR TITLE
Use bot token for releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,7 @@ jobs:
         with:
           ref: main
           fetch-depth: 0 # fetch all commits so auto-changelog is correctly generating
+          token: ${{ secrets.BOT_ACCESS_TOKEN }}
 
       - name: Setup Node
         uses: actions/setup-node@v3


### PR DESCRIPTION
## Changes

Use bot token in order to be able to support branch protection

## Checklist

- [X] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
