### PR TITLE
Introduce vite for dual builds

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,28 +10,28 @@ There are a few basic ground-rules for contributors:
 
 ## Releases
 
-* Releases are done automatically after pull requests are merged.
-* Please label your PR in accordance with requirements of [SemVer](https://semver.org/).
-* Do not bump version numbers in pull requests.
+- Releases are done automatically after pull requests are merged.
+- Please label your PR in accordance with requirements of [SemVer](https://semver.org/).
+- Do not bump version numbers in pull requests.
 
 ## Developer's Certificate of Origin 1.1
 
 By making a contribution to this project, I certify that:
 
-* (a) The contribution was created in whole or in part by me and I have the
+- (a) The contribution was created in whole or in part by me and I have the
   right to submit it under the open source license indicated in the file; or
 
-* (b) The contribution is based upon previous work that, to the best of my
+- (b) The contribution is based upon previous work that, to the best of my
   knowledge, is covered under an appropriate open source license and I have the
   right under that license to submit that work with modifications, whether
   created in whole or in part by me, under the same open source license (unless
   I am permitted to submit under a different license), as indicated in the file;
   or
 
-* (c) The contribution was provided directly to me by some other person who
+- (c) The contribution was provided directly to me by some other person who
   certified (a), (b) or (c) and I have not modified it.
 
-* (d) I understand and agree that this project and the contribution are public
+- (d) I understand and agree that this project and the contribution are public
   and that a record of the contribution (including all personal information I
   submit with it, including my sign-off) is maintained indefinitely and may be
   redistributed consistent with this project or the open source license(s)

--- a/package.json
+++ b/package.json
@@ -16,39 +16,51 @@
     "LICENSE",
     "README.md"
   ],
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
-  "type": "commonjs",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "type": "module",
   "publishConfig": {
     "access": "public"
   },
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "require": "./dist/index.cjs",
+      "import": "./dist/index.js"
+    }
+  },
   "scripts": {
-    "build": "shx rm -rf ./dist && tsc",
+    "build": "rimraf dist && vite build",
+    "build:ts": "shx rm -rf ./dist && tsc",
     "test": "jest",
     "test:coverage": "jest --coverage",
     "test:ci": "npm run lint && npm run test:coverage",
-    "lint": "eslint .",
-    "lint:fix": "eslint . --fix",
-    "format": "prettier --write .",
+    "lint": "eslint --cache --max-warnings=0 . && prettier --check --log-level warn src \"**/*.{json,md,ts,tsx}\" && tsc --noEmit",
+    "lint:fix": "prettier --write src \"**/*.{json,md,ts,tsx}\" --log-level=warn && eslint . --fix",
     "version": "auto-changelog -p && git add CHANGELOG.md"
   },
+  "dependencies": {},
   "devDependencies": {
+    "@lokalise/package-vite-config": "^2.0.0",
     "@types/jest": "^29.5.11",
-    "@types/node": "^18.19.3",
-    "@typescript-eslint/eslint-plugin": "^6.14.0",
-    "@typescript-eslint/parser": "^6.14.0",
+    "@types/node": "^20.12.7",
+    "@typescript-eslint/eslint-plugin": "^7.8.0",
+    "@typescript-eslint/parser": "^7.8.0",
     "auto-changelog": "^2.4.0",
     "eslint": "^8.55.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-import": "^2.29.0",
-    "eslint-plugin-jest": "^27.6.0",
+    "eslint-plugin-jest": "^28.3.0",
     "eslint-plugin-prettier": "^5.0.1",
     "jest": "^29.7.0",
     "prettier": "^3.1.1",
+    "rimraf": "^5.0.5",
     "shx": "^0.3.4",
-    "ts-jest": "^29.1.1",
-    "ts-node": "^10.9.1",
-    "typescript": "^5.3.3",
+    "ts-jest": "^29.1.2",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.4.5",
+    "vite": "^5.2.10",
     "zod": "^3.22.4"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,13 +1,14 @@
 {
   "compilerOptions": {
     "outDir": "dist",
-    "module": "commonjs",
+    "module": "ESNext",
     "target": "ES2022",
     "lib": ["ES2022"],
     "sourceMap": true,
     "declaration": true,
     "declarationMap": false,
     "types": ["node", "jest"],
+    "skipLibCheck": true,
     "strict": true,
     "moduleResolution": "node",
     "noUnusedLocals": false,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,12 @@
+import { resolve } from 'node:path'
+
+// eslint-disable-next-line import/no-unresolved
+import defineConfig from '@lokalise/package-vite-config/package'
+
+import packageJson from './package.json'
+
+/* eslint-disable import/no-default-export */
+export default defineConfig({
+  entry: resolve(__dirname, 'src/index.ts'),
+  dependencies: Object.keys(packageJson.dependencies),
+})


### PR DESCRIPTION
## Changes

This allows publishing both CJS and ESM builds

## Checklist

- [X] Apply one of following labels; `major`, `minor`, `patch` or `skip-release`
- [X] I've updated the documentation, or no changes were necessary
- [X] I've updated the tests, or no changes were necessary
